### PR TITLE
Allow customisation of host running Musly server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
+.DS_Store
+.idea/
+*.zip
 repo.xml

--- a/MusicSimilarity/HTML/EN/plugins/MusicSimilarity/settings/musicsimilarity.html
+++ b/MusicSimilarity/HTML/EN/plugins/MusicSimilarity/settings/musicsimilarity.html
@@ -39,6 +39,10 @@
             <input type="text" class="stdedit sliderInput_2_20_1" name="pref_dstm_tracks" id="dstm_tracks" value="[% prefs.pref_dstm_tracks %]" size="5">
         [% END %]
 
+        [% WRAPPER settingGroup title="MUSICSIMILARITY_API_HOST" desc="MUSICSIMILARITY_API_HOST_DESC" %]
+            <input type="text" class="stdedit" name="pref_host" id="host" value="[% prefs.pref_host %]" size="15">
+        [% END %]
+
         [% WRAPPER settingGroup title="MUSICSIMILARITY_API_PORT" desc="MUSICSIMILARITY_API_PORT_DESC" %]
             <input type="text" class="stdedit" name="pref_port" id="port" value="[% prefs.pref_port %]" size="5">
         [% END %]

--- a/MusicSimilarity/Plugin.pm
+++ b/MusicSimilarity/Plugin.pm
@@ -57,6 +57,7 @@ sub initPlugin {
     $prefs->init({
         filter_genres    => 0,
         filter_xmas      => 1,
+        host             => 'localhost',
         port             => 11000,
         min_duration     => 0,
         max_duration     => 0,
@@ -156,8 +157,9 @@ sub _dstmMix {
 
             my $dstm_tracks = $prefs->get('dstm_tracks') || $DEF_NUM_DSTM_TRACKS;
             my $jsonData = _getMixData(\@seedsToUse, $previousTracks ? \@$previousTracks : undef, $dstm_tracks, 1, $filterGenres);
+            my $host = $prefs->get('host') || 'localhost';
             my $port = $prefs->get('port') || 11000;
-            my $url = "http://localhost:$port/api/similar";
+            my $url = "http://$host:$port/api/similar";
             Slim::Networking::SimpleAsyncHTTP->new(
                 sub {
                     my $response = shift;
@@ -503,8 +505,9 @@ sub cliMix {
     if (scalar @seedsToUse > 0) {
         my $maxTracks = $isMix ? $NUM_MIX_TRACKS : $NUM_SIMILAR_TRACKS;
         my $jsonData = $isMix ? _getMixData(\@seedsToUse, undef, $maxTracks * 2, 1, $prefs->get('filter_genres') || 0) : _getSimilarData(@seedsToUse[0], $request->getParam('byArtist') || 0, $maxTracks);
+        my $host = $prefs->get('host') || 'localhost';
         my $port = $prefs->get('port') || 11000;
-        my $url = $isMix ? "http://localhost:$port/api/similar" : "http://localhost:$port/api/dump";
+        my $url = $isMix ? "http://$host:$port/api/similar" : "http://$host:$port/api/dump";
         $request->setStatusProcessing();
         Slim::Networking::SimpleAsyncHTTP->new(
             sub {

--- a/MusicSimilarity/Settings.pm
+++ b/MusicSimilarity/Settings.pm
@@ -32,7 +32,7 @@ sub page {
 }
 
 sub prefs {
-	return ($prefs, qw(port filter_genres filter_xmas exclude_artists exclude_albums min_duration max_duration no_repeat_artist no_repeat_album no_repeat_track dstm_tracks));
+	return ($prefs, qw(host port filter_genres filter_xmas exclude_artists exclude_albums min_duration max_duration no_repeat_artist no_repeat_album no_repeat_track dstm_tracks));
 }
 
 sub handler {

--- a/MusicSimilarity/strings.txt
+++ b/MusicSimilarity/strings.txt
@@ -18,6 +18,12 @@ MUSICSIMILARITY_FILTER_XMAS
 MUSICSIMILARITY_FILTER_XMAS_DESC
 	EN	Exclude tracks tagged with 'Christmas' genre, unless in December (Default: Yes)
 
+MUSICSIMILARITY_API_HOST
+	EN	API Server Host
+
+MUSICSIMILARITY_API_HOST_DESC
+	EN	Host on which the Essentia or Musly API server is running.
+
 MUSICSIMILARITY_API_PORT
 	EN	API Server HTTP Port
 


### PR DESCRIPTION
This is a straight forward change to allow for customising the API hostname as I found that when running LMS within Docker, "localhost" wasn't working when running musly on the host machine (outside of Docker). It naturally also allows anyone to run Musly on a totally separate box to the LMS server too.

PS- Love all your work on the LMS Material skin and this Musly integration. Keep up the great work! :)
